### PR TITLE
Add Minecraft whitelist application

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Minecraft applications
+
+The `/minecraft` page uses these environment variables:
+
+```bash
+NUXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/your-invite
+MINECRAFT_APPLICATION_DESTINATION=https://your-form-or-webhook-endpoint.example/applications
+MINECRAFT_EMAIL_PROVIDER=your-provider-name
+DISCORD_MINECRAFT_APPLICATION_WEBHOOK=https://discord.com/api/webhooks/...
+MAILERLITE_API_TOKEN=...
+MAILERLITE_GROUP_ID=...
+```
+
+Configure at least one application delivery target: `DISCORD_MINECRAFT_APPLICATION_WEBHOOK` or `MINECRAFT_APPLICATION_DESTINATION`. `MINECRAFT_APPLICATION_DESTINATION` must accept a JSON `POST`. `MAILERLITE_API_TOKEN` and `MAILERLITE_GROUP_ID` are required only when email opt-ins should be sent to MailerLite. Keep private values in `.env` and Vercel environment variables; never commit them.

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,11 +10,12 @@
                     <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-200 rounded-box w-52 gap-2">
                         <li><a href="/">Home</a></li>
                         <li><a href="/about">About</a></li>
-                        <li><a href="#skits">Skits</a></li>
-                        <li><a href="#music">Music</a></li>
-                        <li><a href="#gaming">Gaming</a></li>
+                        <li><a href="/#skits">Skits</a></li>
+                        <li><a href="/#music">Music</a></li>
+                        <li><a href="/#gaming">Gaming</a></li>
+                        <li><NuxtLink to="/minecraft">Minecraft</NuxtLink></li>
                         <li><a href="https://alternate-era.printify.me/" target="_blank" rel="noopener noreferrer">Store</a></li>
-                        <li><a href="#contact">Contact</a></li>
+                        <li><a href="/#contact">Contact</a></li>
                     </ul>
                 </div>
                 <NuxtLink to="/" class="btn btn-ghost px-2">
@@ -25,11 +26,12 @@
             <ul class="menu menu-horizontal px-1 gap-4 font-bold tracking-wide">
                     <li><a href="/" class="hover:text-primary transition-colors">Home</a></li>
                     <li><a href="/about" class="hover:text-primary transition-colors">About</a></li>
-                    <li><a href="#skits" class="hover:text-primary transition-colors">Skits</a></li>
-                    <li><a href="#music" class="hover:text-secondary transition-colors">Music</a></li>
-                    <li><a href="#gaming" class="hover:text-accent transition-colors">Gaming</a></li>
+                    <li><a href="/#skits" class="hover:text-primary transition-colors">Skits</a></li>
+                    <li><a href="/#music" class="hover:text-secondary transition-colors">Music</a></li>
+                    <li><a href="/#gaming" class="hover:text-accent transition-colors">Gaming</a></li>
+                    <li><NuxtLink to="/minecraft" class="hover:text-success transition-colors">Minecraft</NuxtLink></li>
                     <li><a href="https://alternate-era.printify.me/" target="_blank" rel="noopener noreferrer" class="hover:text-primary transition-colors">Store</a></li>
-                    <li><a href="#contact" class="btn btn-primary btn-sm ml-4 shadow-[0_0_15px_var(--color-primary)]">Follow Us</a></li>
+                    <li><a href="/#contact" class="btn btn-primary btn-sm ml-4 shadow-[0_0_15px_var(--color-primary)]">Follow Us</a></li>
                 </ul>
             </div>
         </nav>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,9 +62,15 @@ export default defineNuxtConfig({
         "/store": { redirect: { to: "https://alternate-era.printify.me/", statusCode: 302 } },
     },
     runtimeConfig: {
+        minecraftApplicationDestination: process.env.MINECRAFT_APPLICATION_DESTINATION,
+        minecraftEmailProvider: process.env.MINECRAFT_EMAIL_PROVIDER,
+        mailerliteApiToken: process.env.MAILERLITE_API_TOKEN,
+        mailerliteGroupId: process.env.MAILERLITE_GROUP_ID,
+        discordMinecraftApplicationWebhook: process.env.DISCORD_MINECRAFT_APPLICATION_WEBHOOK,
         youtubeApiKey: process.env.YOUTUBE_API_KEY,
         youtubeChannelId: process.env.YOUTUBE_CHANNEL_ID,
         public: {
+            discordInviteUrl: process.env.NUXT_PUBLIC_DISCORD_INVITE_URL,
             metapixel: {
                 default: { id: "" },
             },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -63,6 +63,7 @@ const { data: youtubeShortsData } = await useFetch('/api/youtube-shorts');
                         <a href="#skits" class="btn btn-outline border-primary text-primary-content hover:bg-primary hover:text-base-100 box-neon-primary rounded-none border-2">Skits</a>
                         <a href="#music" class="btn btn-outline border-secondary text-secondary-content hover:bg-secondary hover:text-base-100 box-neon-secondary rounded-none border-2">Music</a>
                         <a href="#gaming" class="btn btn-outline border-accent text-accent-content hover:bg-accent hover:text-base-100 box-neon-accent rounded-none border-2">Gaming</a>
+                        <NuxtLink to="/minecraft" class="btn btn-outline border-success text-success hover:bg-success hover:text-base-100 rounded-none border-2">Apply for Minecraft</NuxtLink>
                         <a href="/about" class="btn btn-outline border-secondary text-secondary-content hover:bg-secondary hover:text-base-100 box-neon-secondary rounded-none border-2">About</a>
                         <a href="https://alternate-era.printify.me/" target="_blank" rel="noopener noreferrer" class="btn btn-outline border-primary text-primary-content hover:bg-primary hover:text-base-100 box-neon-primary rounded-none border-2">Store</a>
                     </div>

--- a/pages/minecraft.vue
+++ b/pages/minecraft.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+useSeoMeta({
+    title: "Alternate Era Minecraft | Join the Community SMP",
+    description: "Apply to join the Alternate Era Minecraft server. A community survival server supporting Java, Bedrock, and console players via BedrockConnect.",
+    ogTitle: "Alternate Era Minecraft | Join the Community SMP",
+    ogDescription: "Apply to join our community-driven Minecraft survival server for Java, Bedrock, and console players.",
+});
+
+const config = useRuntimeConfig();
+const discordInviteUrl = computed(() => config.public.discordInviteUrl || "#discord-required");
+const platforms = ["Java PC", "Bedrock PC", "Xbox", "PlayStation", "Nintendo Switch", "Mobile", "Other"];
+const ageRanges = ["Under 13", "13–17", "18+"];
+const playerTypeOptions = ["Builder", "Explorer", "Redstone Engineer", "Farmer", "Miner", "PvP", "Casual", "Content Creator / Stream Viewer"];
+const steps = [
+    "Join the Alternate Era Discord (required)",
+    "Submit your SMP application",
+    "Staff reviews your application",
+    "Approved players are whitelisted",
+    "Begin your adventure as a Trial Member",
+    "Earn Trusted Member status by being a positive part of the community",
+];
+const rules = [
+    "No griefing.",
+    "No stealing.",
+    "No hacking.",
+    "No x-ray mods or resource packs.",
+    "No duping or exploit abuse.",
+    "No world seed viewers, seed mapping tools, or software that reveals undiscovered terrain, structures, ores, or hidden world information.",
+    "No harassment, hate speech, threats, or inappropriate content.",
+    "Respect spawn, community builds, and other players' bases.",
+    "Follow the Discord and livestream community rules.",
+    "Staff decisions are final when protecting the community.",
+];
+
+const form = reactive({
+    email: "",
+    discordUsername: "",
+    joinedDiscord: false,
+    javaUsername: "",
+    bedrockGamertag: "",
+    platform: "",
+    ageRange: "",
+    whyJoin: "",
+    playerTypes: [] as string[],
+    banHistory: "",
+    banExplanation: "",
+    agreesRules: false,
+    understandsNoGuarantee: false,
+    emailOptIn: false,
+});
+const errors = ref<Record<string, string>>({});
+const submitting = ref(false);
+const submitted = ref(false);
+const submitError = ref("");
+
+watch(() => form.platform, (platform) => {
+    if (platform === "Java PC") form.bedrockGamertag = "";
+    else form.javaUsername = "";
+});
+
+function validate() {
+    const next: Record<string, string> = {};
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) next.email = "Enter a valid email address.";
+    if (!form.discordUsername.trim()) next.discordUsername = "Discord username is required.";
+    if (!form.joinedDiscord) next.joinedDiscord = "Join Discord before applying.";
+    if (!form.platform) next.platform = "Choose your primary platform.";
+    if (form.platform === "Java PC" && !form.javaUsername.trim()) next.javaUsername = "Java username is required.";
+    if (form.platform && form.platform !== "Java PC" && !form.bedrockGamertag.trim()) next.bedrockGamertag = "Bedrock gamertag is required.";
+    if (!form.ageRange) next.ageRange = "Choose an age range.";
+    if (!form.whyJoin.trim()) next.whyJoin = "Tell us why you want to join.";
+    if (!form.playerTypes.length) next.playerTypes = "Choose at least one player type.";
+    if (!form.banHistory) next.banHistory = "Answer this question.";
+    if (form.banHistory === "Yes" && !form.banExplanation.trim()) next.banExplanation = "Please explain the ban.";
+    if (!form.agreesRules) next.agreesRules = "You must agree to the rules.";
+    if (!form.understandsNoGuarantee) next.understandsNoGuarantee = "You must confirm this statement.";
+    errors.value = next;
+    return !Object.keys(next).length;
+}
+
+async function submitApplication() {
+    submitError.value = "";
+    if (!validate()) return;
+    submitting.value = true;
+    try {
+        await $fetch("/api/minecraft-application", { method: "POST", body: form });
+        submitted.value = true;
+    } catch (error: any) {
+        submitError.value = error?.data?.statusMessage || "Application could not be submitted. Please try again later.";
+    } finally {
+        submitting.value = false;
+    }
+}
+</script>
+
+<template>
+    <div class="bg-base-100">
+        <section class="minecraft-grid relative isolate overflow-hidden border-b border-secondary/30 py-24 md:py-36">
+            <div class="absolute inset-0 -z-10 bg-gradient-to-br from-primary/30 via-base-100/90 to-secondary/20"></div>
+            <div class="container mx-auto px-4 text-center">
+                <p class="mb-4 font-mono text-sm font-bold uppercase tracking-[0.35em] text-secondary">Application-only community SMP</p>
+                <h1 class="mx-auto max-w-5xl text-5xl font-black uppercase tracking-tight text-neon md:text-7xl">Join the Alternate Era Minecraft Server</h1>
+                <p class="mx-auto mt-6 max-w-3xl text-lg text-base-content/80 md:text-xl">A community-driven survival server for Alternate Era viewers, builders, adventurers, creators, and chill players who want a long-term world free from griefers and toxicity.</p>
+                <div class="mt-8 flex flex-wrap justify-center gap-3" aria-label="Supported Minecraft editions">
+                    <span class="badge badge-lg badge-primary">Java Edition</span>
+                    <span class="badge badge-lg badge-secondary">Bedrock Edition</span>
+                    <span class="badge badge-lg badge-success">Console via BedrockConnect</span>
+                </div>
+                <div class="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
+                    <a :href="discordInviteUrl" :target="config.public.discordInviteUrl ? '_blank' : undefined" rel="noopener noreferrer" class="btn btn-primary btn-lg box-neon-primary">Join the Discord</a>
+                    <a href="#application" class="btn btn-outline btn-secondary btn-lg">Apply for Whitelist</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="border-b border-base-300 bg-base-200 py-20">
+            <div class="container mx-auto grid gap-10 px-4 lg:grid-cols-2 lg:items-center">
+                <div>
+                    <p class="mb-3 font-mono uppercase tracking-widest text-secondary">A world worth protecting</p>
+                    <h2 class="text-4xl font-black uppercase md:text-5xl">Community over player count</h2>
+                    <p class="mt-6 text-lg text-base-content/80">This is not intended to be a massive public server. We grow slowly so players can know and trust one another. Protecting the community comes first.</p>
+                </div>
+                <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                    <div v-for="item in ['Building', 'Exploring', 'Community projects', 'Livestream events', 'Helping others', 'A lasting world']" :key="item" class="card border border-primary/30 bg-base-100 p-5 text-center font-bold shadow-lg">{{ item }}</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20">
+            <div class="container mx-auto max-w-4xl px-4 text-center">
+                <Icon name="heroicons:lock-closed" class="mx-auto mb-5 h-12 w-12 text-secondary" />
+                <h2 class="text-4xl font-black uppercase md:text-5xl">Why application only?</h2>
+                <div class="mt-6 space-y-4 text-lg text-base-content/80">
+                    <p>The Alternate Era Minecraft server is intentionally application-based. We would rather build a smaller community filled with trustworthy people than a giant public server full of griefers, hackers, and trolls.</p>
+                    <p>Every player helps shape the world, so we take time to get to know new members before opening the gates.</p>
+                    <p class="font-bold text-base-content">Looking for a long-term Minecraft home where people respect one another and work together? You’ll fit right in.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="border-y border-secondary/30 bg-base-300 py-20">
+            <div class="container mx-auto px-4">
+                <h2 class="mb-12 text-center text-4xl font-black uppercase md:text-5xl">How it works</h2>
+                <ol class="mx-auto grid max-w-6xl gap-4 md:grid-cols-3">
+                    <li v-for="(step, index) in steps" :key="step" class="card border border-secondary/30 bg-base-100 p-6 shadow-xl">
+                        <span class="mb-3 font-mono text-3xl font-black text-secondary">0{{ index + 1 }}</span>
+                        <span class="font-bold">{{ step }}</span>
+                    </li>
+                </ol>
+            </div>
+        </section>
+
+        <section id="rules" class="py-20">
+            <div class="container mx-auto max-w-5xl px-4">
+                <h2 class="mb-4 text-center text-4xl font-black uppercase md:text-5xl">Protect the world</h2>
+                <p class="mb-10 text-center text-base-content/70">Simple standards. Good neighbors. Staff decisions are final when protecting the community.</p>
+                <ul class="grid gap-3 md:grid-cols-2">
+                    <li v-for="rule in rules" :key="rule" class="flex gap-3 rounded-box border border-base-300 bg-base-200 p-4">
+                        <Icon name="heroicons:check-circle" class="h-6 w-6 shrink-0 text-success" />
+                        <span>{{ rule }}</span>
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <section id="application" class="border-t border-primary/30 bg-base-200 py-20">
+            <div class="container mx-auto max-w-4xl px-4">
+                <div v-if="submitted" class="card border border-success/40 bg-base-100 p-8 text-center shadow-2xl md:p-12" role="status">
+                    <Icon name="heroicons:check-badge" class="mx-auto mb-5 h-16 w-16 text-success" />
+                    <h2 class="text-3xl font-black uppercase">Application received!</h2>
+                    <p class="mt-4 text-lg">Join us in Discord while our staff reviews your application. We'll contact you there if you're accepted.</p>
+                    <a :href="discordInviteUrl" class="btn btn-primary mx-auto mt-8">Join the Discord</a>
+                </div>
+
+                <div v-else>
+                    <div class="mb-10 text-center">
+                        <p class="mb-3 font-mono uppercase tracking-widest text-primary">Whitelist application</p>
+                        <h2 class="text-4xl font-black uppercase md:text-5xl">Ready to build?</h2>
+                        <p id="discord-required" class="mt-4 text-lg"><strong>Discord membership is required before applying.</strong> <a :href="discordInviteUrl" class="link link-secondary">Join Discord first</a>, then return here.</p>
+                    </div>
+
+                    <form class="card space-y-8 border border-primary/30 bg-base-100 p-6 shadow-2xl md:p-10" novalidate @submit.prevent="submitApplication">
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <label class="form-control">
+                                <span class="label-text mb-2 font-bold">Email address *</span>
+                                <input v-model.trim="form.email" type="email" autocomplete="email" class="input input-bordered" :class="{ 'input-error': errors.email }" aria-describedby="email-error" required />
+                                <span v-if="errors.email" id="email-error" class="mt-1 text-sm text-error">{{ errors.email }}</span>
+                            </label>
+                            <label class="form-control">
+                                <span class="label-text mb-2 font-bold">Discord username *</span>
+                                <input v-model.trim="form.discordUsername" type="text" autocomplete="username" class="input input-bordered" :class="{ 'input-error': errors.discordUsername }" aria-describedby="discord-error" required />
+                                <span v-if="errors.discordUsername" id="discord-error" class="mt-1 text-sm text-error">{{ errors.discordUsername }}</span>
+                            </label>
+                        </div>
+
+                        <label class="flex items-start gap-3">
+                            <input v-model="form.joinedDiscord" type="checkbox" class="checkbox checkbox-primary mt-1" required />
+                            <span><strong>I have joined the Alternate Era Discord. *</strong><span v-if="errors.joinedDiscord" class="block text-sm text-error">{{ errors.joinedDiscord }}</span></span>
+                        </label>
+
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <label class="form-control">
+                                <span class="label-text mb-2 font-bold">Primary platform *</span>
+                                <select v-model="form.platform" class="select select-bordered" :class="{ 'select-error': errors.platform }" required>
+                                    <option disabled value="">Choose a platform</option>
+                                    <option v-for="platform in platforms" :key="platform">{{ platform }}</option>
+                                </select>
+                                <span v-if="errors.platform" class="mt-1 text-sm text-error">{{ errors.platform }}</span>
+                            </label>
+                            <label v-if="form.platform === 'Java PC'" class="form-control">
+                                <span class="label-text mb-2 font-bold">Minecraft Java username *</span>
+                                <input v-model.trim="form.javaUsername" type="text" class="input input-bordered" :class="{ 'input-error': errors.javaUsername }" required />
+                                <span v-if="errors.javaUsername" class="mt-1 text-sm text-error">{{ errors.javaUsername }}</span>
+                            </label>
+                            <label v-else-if="form.platform" class="form-control">
+                                <span class="label-text mb-2 font-bold">Minecraft Bedrock gamertag *</span>
+                                <input v-model.trim="form.bedrockGamertag" type="text" class="input input-bordered" :class="{ 'input-error': errors.bedrockGamertag }" required />
+                                <span v-if="errors.bedrockGamertag" class="mt-1 text-sm text-error">{{ errors.bedrockGamertag }}</span>
+                            </label>
+                            <label class="form-control">
+                                <span class="label-text mb-2 font-bold">Age range *</span>
+                                <select v-model="form.ageRange" class="select select-bordered" :class="{ 'select-error': errors.ageRange }" required>
+                                    <option disabled value="">Choose an age range</option>
+                                    <option v-for="age in ageRanges" :key="age">{{ age }}</option>
+                                </select>
+                                <span v-if="errors.ageRange" class="mt-1 text-sm text-error">{{ errors.ageRange }}</span>
+                            </label>
+                        </div>
+
+                        <div v-if="form.ageRange === 'Under 13'" class="alert alert-warning" role="note">
+                            <Icon name="heroicons:information-circle" class="h-6 w-6" />
+                            <span>Younger players may need permission from a parent or guardian under community policy. Please do not include extra personal information in your answers.</span>
+                        </div>
+
+                        <label class="form-control">
+                            <span class="label-text mb-2 font-bold">Why do you want to join the Alternate Era Minecraft server? *</span>
+                            <textarea v-model.trim="form.whyJoin" rows="5" class="textarea textarea-bordered" :class="{ 'textarea-error': errors.whyJoin }" required></textarea>
+                            <span v-if="errors.whyJoin" class="mt-1 text-sm text-error">{{ errors.whyJoin }}</span>
+                        </label>
+
+                        <fieldset>
+                            <legend class="mb-3 font-bold">What kind of player are you? *</legend>
+                            <div class="grid gap-3 sm:grid-cols-2">
+                                <label v-for="type in playerTypeOptions" :key="type" class="flex items-center gap-3 rounded-box border border-base-300 p-3">
+                                    <input v-model="form.playerTypes" type="checkbox" :value="type" class="checkbox checkbox-secondary" />
+                                    <span>{{ type }}</span>
+                                </label>
+                            </div>
+                            <p v-if="errors.playerTypes" class="mt-2 text-sm text-error">{{ errors.playerTypes }}</p>
+                        </fieldset>
+
+                        <fieldset>
+                            <legend class="mb-3 font-bold">Have you ever been banned from a Minecraft server? *</legend>
+                            <div class="flex gap-6">
+                                <label v-for="answer in ['No', 'Yes']" :key="answer" class="flex items-center gap-2"><input v-model="form.banHistory" type="radio" :value="answer" class="radio radio-primary" /> {{ answer }}</label>
+                            </div>
+                            <p v-if="errors.banHistory" class="mt-2 text-sm text-error">{{ errors.banHistory }}</p>
+                        </fieldset>
+
+                        <label v-if="form.banHistory === 'Yes'" class="form-control">
+                            <span class="label-text mb-2 font-bold">Please explain *</span>
+                            <textarea v-model.trim="form.banExplanation" rows="4" class="textarea textarea-bordered" :class="{ 'textarea-error': errors.banExplanation }"></textarea>
+                            <span v-if="errors.banExplanation" class="mt-1 text-sm text-error">{{ errors.banExplanation }}</span>
+                        </label>
+
+                        <div class="space-y-4 border-t border-base-300 pt-6">
+                            <label class="flex items-start gap-3"><input v-model="form.agreesRules" type="checkbox" class="checkbox checkbox-primary mt-1" required /><span>I have read and agree to follow the <a href="#rules" class="link link-secondary">server rules</a>. *<span v-if="errors.agreesRules" class="block text-sm text-error">{{ errors.agreesRules }}</span></span></label>
+                            <label class="flex items-start gap-3"><input v-model="form.understandsNoGuarantee" type="checkbox" class="checkbox checkbox-primary mt-1" required /><span>I understand that submitting an application does not guarantee acceptance. *<span v-if="errors.understandsNoGuarantee" class="block text-sm text-error">{{ errors.understandsNoGuarantee }}</span></span></label>
+                            <label class="flex items-start gap-3"><input v-model="form.emailOptIn" type="checkbox" class="checkbox checkbox-secondary mt-1" /><span>I'd like emails about Alternate Era events, Minecraft updates, livestreams, and community announcements. (Optional)</span></label>
+                        </div>
+
+                        <div v-if="submitError" class="alert alert-error" role="alert">{{ submitError }}</div>
+                        <button type="submit" class="btn btn-primary btn-lg w-full" :disabled="submitting">{{ submitting ? "Submitting…" : "Submit application" }}</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </div>
+</template>
+
+<style scoped>
+.minecraft-grid {
+    background-image: linear-gradient(rgb(255 255 255 / 0.035) 1px, transparent 1px), linear-gradient(90deg, rgb(255 255 255 / 0.035) 1px, transparent 1px);
+    background-size: 32px 32px;
+}
+</style>

--- a/server/api/minecraft-application.post.ts
+++ b/server/api/minecraft-application.post.ts
@@ -1,0 +1,107 @@
+const platforms = ["Java PC", "Bedrock PC", "Xbox", "PlayStation", "Nintendo Switch", "Mobile", "Other"];
+const ageRanges = ["Under 13", "13–17", "18+"];
+const playerTypes = ["Builder", "Explorer", "Redstone Engineer", "Farmer", "Miner", "PvP", "Casual", "Content Creator / Stream Viewer"];
+const clip = (value: unknown) => String(value || "—").slice(0, 1024);
+
+export default defineEventHandler(async (event) => {
+    const body = await readBody<Record<string, unknown>>(event);
+    const requiredStrings = ["email", "discordUsername", "platform", "ageRange", "whyJoin", "banHistory"];
+
+    if (requiredStrings.some((field) => typeof body[field] !== "string" || !body[field]?.toString().trim())) {
+        throw createError({ statusCode: 400, statusMessage: "Complete all required fields." });
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email as string)) {
+        throw createError({ statusCode: 400, statusMessage: "Enter a valid email address." });
+    }
+    if (!platforms.includes(body.platform as string) || !ageRanges.includes(body.ageRange as string)) {
+        throw createError({ statusCode: 400, statusMessage: "Choose a valid platform and age range." });
+    }
+    const usernameField = body.platform === "Java PC" ? "javaUsername" : "bedrockGamertag";
+    if (typeof body[usernameField] !== "string" || !body[usernameField].trim()) {
+        throw createError({ statusCode: 400, statusMessage: body.platform === "Java PC" ? "Enter your Java username." : "Enter your Bedrock gamertag." });
+    }
+    if (!Array.isArray(body.playerTypes) || !body.playerTypes.length || body.playerTypes.some((type) => !playerTypes.includes(type))) {
+        throw createError({ statusCode: 400, statusMessage: "Choose at least one player type." });
+    }
+    if (body.banHistory !== "No" && body.banHistory !== "Yes") {
+        throw createError({ statusCode: 400, statusMessage: "Answer the server ban question." });
+    }
+    if (body.banHistory === "Yes" && (typeof body.banExplanation !== "string" || !body.banExplanation.trim())) {
+        throw createError({ statusCode: 400, statusMessage: "Explain the previous server ban." });
+    }
+    if (body.joinedDiscord !== true || body.agreesRules !== true || body.understandsNoGuarantee !== true) {
+        throw createError({ statusCode: 400, statusMessage: "Confirm Discord membership and both required agreements." });
+    }
+
+    const config = useRuntimeConfig(event);
+    if (!config.minecraftApplicationDestination && !config.discordMinecraftApplicationWebhook) {
+        throw createError({ statusCode: 503, statusMessage: "Application service is not configured yet." });
+    }
+    if (body.emailOptIn === true && (!config.mailerliteApiToken || !config.mailerliteGroupId)) {
+        throw createError({ statusCode: 503, statusMessage: "Email opt-in service is not configured yet." });
+    }
+
+    try {
+        const submittedAt = new Date().toISOString();
+        const application = {
+            ...body,
+            submittedAt,
+            emailProvider: body.emailOptIn ? config.minecraftEmailProvider || "MailerLite" : null,
+        };
+
+        if (config.minecraftApplicationDestination) {
+            await $fetch(config.minecraftApplicationDestination, {
+                method: "POST",
+                body: application,
+            });
+        }
+
+        if (config.discordMinecraftApplicationWebhook) {
+            await $fetch(config.discordMinecraftApplicationWebhook, {
+                method: "POST",
+                body: {
+                    username: "Minecraft Applications",
+                    allowed_mentions: { parse: [] },
+                    embeds: [{
+                        title: "New Minecraft Application",
+                        color: 0x57f287,
+                        timestamp: submittedAt,
+                        fields: [
+                            { name: "Email", value: clip(body.email), inline: true },
+                            { name: "Discord", value: clip(body.discordUsername), inline: true },
+                            { name: "Platform", value: clip(body.platform), inline: true },
+                            { name: "Minecraft Name", value: clip(body.javaUsername || body.bedrockGamertag), inline: true },
+                            { name: "Age", value: clip(body.ageRange), inline: true },
+                            { name: "Email opt-in", value: body.emailOptIn ? "Yes" : "No", inline: true },
+                            { name: "Player types", value: clip((body.playerTypes as string[]).join(", ")) },
+                            { name: "Ban history", value: clip(body.banHistory === "Yes" ? body.banExplanation : "No") },
+                            { name: "Why join?", value: clip(body.whyJoin) },
+                        ],
+                    }],
+                },
+            });
+        }
+
+        if (body.emailOptIn === true) {
+            await $fetch("https://connect.mailerlite.com/api/subscribers", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${config.mailerliteApiToken}`,
+                    Accept: "application/json",
+                },
+                body: {
+                    email: body.email,
+                    groups: [config.mailerliteGroupId],
+                    fields: {
+                        discord_username: body.discordUsername,
+                        minecraft_platform: body.platform,
+                    },
+                },
+            });
+        }
+    } catch {
+        throw createError({ statusCode: 502, statusMessage: "Application could not be delivered. Please try again later." });
+    }
+
+    return { ok: true };
+});


### PR DESCRIPTION
## Summary

- Add `/minecraft` SMP landing page and whitelist application form
- Add server-side validation with Java-only Java username and Bedrock gamertag for other platforms
- Send applications to Discord webhook or generic JSON endpoint
- Send opted-in emails to MailerLite group

## Validation

- `bun run build`
- Local dry run delivered Discord webhook message and MailerLite group signup
