### PR TITLE
Add Minecraft reCAPTCHA checkbox

### DIFF
--- a/pages/minecraft.vue
+++ b/pages/minecraft.vue
@@ -53,6 +53,15 @@ const submitting = ref(false);
 const submitted = ref(false);
 const submitError = ref("");
 
+onMounted(() => {
+    if (document.querySelector('script[src="https://www.google.com/recaptcha/api.js"]')) return;
+    const script = document.createElement("script");
+    script.src = "https://www.google.com/recaptcha/api.js";
+    script.async = true;
+    script.defer = true;
+    document.body.appendChild(script);
+});
+
 watch(() => form.platform, (platform) => {
     if (platform === "Java PC") form.bedrockGamertag = "";
     else form.javaUsername = "";
@@ -80,6 +89,11 @@ function validate() {
 async function submitApplication() {
     submitError.value = "";
     if (!validate()) return;
+    const recaptchaResponse = document.querySelector<HTMLTextAreaElement>('[name="g-recaptcha-response"]')?.value;
+    if (!recaptchaResponse) {
+        submitError.value = "Please complete the reCAPTCHA.";
+        return;
+    }
     submitting.value = true;
     try {
         await $fetch("/api/minecraft-application", { method: "POST", body: form });
@@ -268,6 +282,7 @@ async function submitApplication() {
                             <label class="flex items-start gap-3"><input v-model="form.emailOptIn" type="checkbox" class="checkbox checkbox-secondary mt-1" /><span>I'd like emails about Alternate Era events, Minecraft updates, livestreams, and community announcements. (Optional)</span></label>
                         </div>
 
+                        <div class="g-recaptcha" data-sitekey="6Lf1KHQUAAAAAFNKEX1hdSWCS3mRMv4FlFaNslaD"></div>
                         <div v-if="submitError" class="alert alert-error" role="alert">{{ submitError }}</div>
                         <button type="submit" class="btn btn-primary btn-lg w-full" :disabled="submitting">{{ submitting ? "Submitting…" : "Submit application" }}</button>
                     </form>

--- a/pages/minecraft.vue
+++ b/pages/minecraft.vue
@@ -52,13 +52,28 @@ const errors = ref<Record<string, string>>({});
 const submitting = ref(false);
 const submitted = ref(false);
 const submitError = ref("");
+const recaptchaContainer = ref<HTMLElement | null>(null);
+const recaptchaWidgetId = ref<number | null>(null);
+const recaptchaSiteKey = "6Lf1KHQUAAAAAFNKEX1hdSWCS3mRMv4FlFaNslaD";
+
+function renderRecaptcha() {
+    const grecaptcha = (window as any).grecaptcha;
+    if (!recaptchaContainer.value || !grecaptcha?.render || recaptchaWidgetId.value !== null) return;
+    recaptchaWidgetId.value = grecaptcha.render(recaptchaContainer.value, { sitekey: recaptchaSiteKey });
+}
 
 onMounted(() => {
-    if (document.querySelector('script[src="https://www.google.com/recaptcha/api.js"]')) return;
+    const existingScript = document.querySelector<HTMLScriptElement>('script[src^="https://www.google.com/recaptcha/api.js"]');
+    if (existingScript) {
+        renderRecaptcha();
+        existingScript.addEventListener("load", renderRecaptcha, { once: true });
+        return;
+    }
     const script = document.createElement("script");
     script.src = "https://www.google.com/recaptcha/api.js";
     script.async = true;
     script.defer = true;
+    script.addEventListener("load", renderRecaptcha, { once: true });
     document.body.appendChild(script);
 });
 
@@ -89,7 +104,10 @@ function validate() {
 async function submitApplication() {
     submitError.value = "";
     if (!validate()) return;
-    const recaptchaResponse = document.querySelector<HTMLTextAreaElement>('[name="g-recaptcha-response"]')?.value;
+    const grecaptcha = (window as any).grecaptcha;
+    const recaptchaResponse = recaptchaWidgetId.value !== null && grecaptcha?.getResponse
+        ? grecaptcha.getResponse(recaptchaWidgetId.value)
+        : document.querySelector<HTMLTextAreaElement>('[name="g-recaptcha-response"]')?.value;
     if (!recaptchaResponse) {
         submitError.value = "Please complete the reCAPTCHA.";
         return;
@@ -282,7 +300,7 @@ async function submitApplication() {
                             <label class="flex items-start gap-3"><input v-model="form.emailOptIn" type="checkbox" class="checkbox checkbox-secondary mt-1" /><span>I'd like emails about Alternate Era events, Minecraft updates, livestreams, and community announcements. (Optional)</span></label>
                         </div>
 
-                        <div class="g-recaptcha" data-sitekey="6Lf1KHQUAAAAAFNKEX1hdSWCS3mRMv4FlFaNslaD"></div>
+                        <div ref="recaptchaContainer"></div>
                         <div v-if="submitError" class="alert alert-error" role="alert">{{ submitError }}</div>
                         <button type="submit" class="btn btn-primary btn-lg w-full" :disabled="submitting">{{ submitting ? "Submitting…" : "Submit application" }}</button>
                     </form>


### PR DESCRIPTION
## Summary

Adds the same Google reCAPTCHA v2 checkbox used by the contact form to the Minecraft SMP application page.

## Why

The Minecraft application form had no captcha challenge on the latest master, so submissions could proceed without the visible checkbox challenge.

## Changes

- Load Google's reCAPTCHA script on /minecraft.
- Render the hardcoded v2 checkbox site key used by the contact form.
- Block application submission until the checkbox response exists.

## Validation

- bun run build
- git diff --check
- ggshield pre-commit secret scan